### PR TITLE
Basic Enemy Movement, Player Hitbox Changes

### DIFF
--- a/scenes/characters/Enemy.tscn
+++ b/scenes/characters/Enemy.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=26 format=3 uid="uid://bycx5snr304xk"]
+[gd_scene load_steps=28 format=3 uid="uid://bycx5snr304xk"]
 
 [ext_resource type="Script" path="res://scenes/characters/Enemy.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://dgmhft8dl1n3d" path="res://textures/temp-pj/pj.png" id="2"]
@@ -153,9 +153,16 @@ animations = [{
 font_size = 45
 font_color = Color(0.803922, 0.133333, 0.180392, 1)
 
+[sub_resource type="CircleShape2D" id="CircleShape2D_wuu5n"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_wabu1"]
+
 [node name="Enemy" type="CharacterBody2D" groups=["enemies"]]
 position = Vector2(588, 286)
+motion_mode = 1
+wall_min_slide_angle = 0.0
 script = ExtResource("1")
+WALK_SPEED = 150
 
 [node name="sprite" type="Sprite2D" parent="."]
 visible = false
@@ -180,11 +187,8 @@ position = Vector2(6, 14.0211)
 polygon = PackedVector2Array(-134.513, -92.9393, -124.246, 19.4555, -59.4026, 109.155, 76.2278, 112.938, 75.147, 26.4802, -2.66479, 20.5363, -36.1671, -8.64319, -57.2411, -40.5244)
 disabled = true
 
-[node name="state_changer" type="Timer" parent="."]
-autostart = true
-
 [node name="hurtbox" type="Area2D" parent="."]
-position = Vector2(0, -72.0772)
+position = Vector2(0, -49.0772)
 collision_mask = 3
 
 [node name="col" type="CollisionShape2D" parent="hurtbox" groups=["enemy"]]
@@ -215,5 +219,22 @@ metadata/_edit_use_anchors_ = true
 [node name="DamageTimer" type="Timer" parent="."]
 one_shot = true
 
-[connection signal="timeout" from="state_changer" to="." method="_on_state_changer_timeout"]
+[node name="attack_range" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="attack_range"]
+position = Vector2(0, -46)
+scale = Vector2(10, 10)
+shape = SubResource("CircleShape2D_wuu5n")
+
+[node name="sight_range" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="sight_range"]
+position = Vector2(0, -46)
+scale = Vector2(50, 50)
+shape = SubResource("CircleShape2D_wabu1")
+
 [connection signal="body_shape_entered" from="hurtbox" to="." method="_on_hurtbox_body_shape_entered"]
+[connection signal="area_entered" from="attack_range" to="." method="_on_enter_attack_range"]
+[connection signal="area_exited" from="attack_range" to="." method="_on_exit_attack_range"]
+[connection signal="area_entered" from="sight_range" to="." method="_on_enter_sight"]
+[connection signal="area_exited" from="sight_range" to="." method="_on_exit_sight"]

--- a/scenes/characters/Player.tscn
+++ b/scenes/characters/Player.tscn
@@ -12,15 +12,15 @@ radius = 35.8589
 height = 71.7178
 
 [sub_resource type="CapsuleShape2D" id="18"]
-radius = 33.801
-height = 67.6021
+radius = 30.0
+height = 144.16
 
 [node name="Player" type="CharacterBody2D" groups=["player"]]
 motion_mode = 1
 script = ExtResource("2")
 
 [node name="hitbox" type="CollisionShape2D" parent="."]
-position = Vector2(-0.882385, -27.9806)
+position = Vector2(0, 23)
 rotation = 1.5708
 shape = SubResource("1")
 
@@ -41,9 +41,9 @@ properties = ["linear_vel", "roll_direction", "facing"]
 enabled = false
 
 [node name="hurtbox" type="Area2D" parent="."]
+position = Vector2(0, 21)
 
 [node name="col" type="CollisionShape2D" parent="hurtbox"]
-position = Vector2(0, -78.0211)
 shape = SubResource("18")
 
 [node name="anims" type="AnimatedSprite2D" parent="."]


### PR DESCRIPTION
- Enemies now have two new areas, "sight range" and "attack range"
- Enemies will be idle by default
- When a player enters an enemy's sight range, the enemy will begin moving toward the player; when a player exits an enemy's sight range, the enemy will go idle
- When the player enters an enemy's attack range, the enemy will begin attacking the player (damage and animations are not coded yet, so it appears to stop); when the player exits the enemy's attack range, the enemy will begin following the player
- Changed player's hitboxes/hurtboxes to be somewhat more accurate for enemy detection, as well as enemy attacks later on