### PR TITLE
Resize tiles only, no characters moved

### DIFF
--- a/scenes/characters/NpcMovementTest.tscn
+++ b/scenes/characters/NpcMovementTest.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=6 format=3 uid="uid://4c6nil367abb"]
 
 [ext_resource type="Script" path="res://scenes/characters/NpcMovementTest.gd" id="1_l76gx"]
-[ext_resource type="Texture2D" uid="uid://dscm5ic80ak2p" path="res://textures/pj/frames/idle_down0000.png" id="2_07e0u"]
+[ext_resource type="Texture2D" uid="uid://dscm5ic80ak2p" path="res://textures/temp-pj/frames/idle_down0000.png" id="2_07e0u"]
 
 [sub_resource type="Animation" id="1"]
 resource_name = "idle"

--- a/scenes/levels/Outside.tscn
+++ b/scenes/levels/Outside.tscn
@@ -1062,7 +1062,6 @@ position = Vector2(1794.98, 2169.35)
 position = Vector2(1993.98, 2165.35)
 
 [node name="Forest" type="TileMap" parent="level"]
-scale = Vector2(7, 7)
 tile_set = SubResource("TileSet_x747v")
 format = 2
 layer_0/name = "background"


### PR DESCRIPTION
Characters were not moved so as to not cause a conflict with the other branch (lord-radian) that both resized and moved characters. 